### PR TITLE
Limit nesting depth by default to guard against stack overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ unicode-general-category = { version = "1.0" }
 [features]
 default = ["serde"]
 serde = ["dep:serde"]
+unlimited_depth = []
+
+
 
 [dev-dependencies.serde]
 version = "1.0"
@@ -50,3 +53,4 @@ test = true
 
 [package.metadata.docs.rs]
 all-features = true
+

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -494,11 +494,6 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
         match self.check_and_consume(vec![TokType::Plus, TokType::Minus]) {
             None => self.parse_primary(),
             Some(span) => {
-                self.current_depth = self.current_depth + 1;
-                if self.current_depth > self.max_depth {
-                    let idx = self.position();
-                    return Err(self.make_error(format!("max depth ({}) exceeded while parsing unary. To expand the depth, use the ``with_max_depth`` constructor or enable the `unlimited_depth` feature", self.max_depth), idx))
-                }
                 match span.1 {
                     TokType::Plus => {
                         let value = self.parse_unary()?;
@@ -508,7 +503,6 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
-                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Plus, value: Box::new(value)})
                     }
                     TokType::Minus => {
@@ -519,7 +513,6 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
-                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Minus, value: Box::new(value)})
                     }
                     _ => unreachable!("no")

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -251,12 +251,19 @@ struct JSON5Parser<'toks, 'input> {
     source: &'input str,
     source_tokens: Peekable<Iter<'toks, TokenSpan>>,
     lookahead: Option<&'toks TokenSpan>,
+    current_depth: usize,
+    max_depth: usize,
 }
 
 
 impl<'toks, 'input> JSON5Parser<'toks, 'input> {
     fn new(tokens: &'toks Tokens<'input>) -> Self {
-        JSON5Parser { source_tokens: tokens.tok_spans.iter().peekable(), lookahead: None, source: tokens.source }
+        use crate::utils::MAX_DEPTH;
+        JSON5Parser { source_tokens: tokens.tok_spans.iter().peekable(), lookahead: None, source: tokens.source, current_depth: 0, max_depth: MAX_DEPTH }
+    }
+
+    fn with_max_depth(tokens: &'toks Tokens<'input>, max_depth: usize) -> Self {
+        JSON5Parser { source_tokens: tokens.tok_spans.iter().peekable(), lookahead: None, source: tokens.source, current_depth: 0, max_depth: max_depth }
     }
 
     fn advance(&mut self) -> Option<&'toks TokenSpan> {
@@ -529,7 +536,14 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
 
 
     fn parse_value(&mut self) -> Result<JSONValue<'input>, ParsingError> {
-        self.parse_obj_or_array()
+        self.current_depth = self.current_depth + 1;
+        if self.current_depth > self.max_depth {
+            let idx = self.position();
+            return Err(self.make_error(format!("max depth ({}) exceeded in nested arrays/objects. To expand the depth, use the ``with_max_depth`` constructor or enable the `unlimited_depth` feature", self.max_depth), idx))
+        }
+        let res = self.parse_obj_or_array();
+        self.current_depth = self.current_depth - 1;
+        res
     }
 
     fn parse_text(&mut self) -> Result<JSONText<'input>, ParsingError> {
@@ -605,6 +619,23 @@ mod tests {
         let res = from_str("0xA18 {9");
         assert!(res.is_err());
     }
+
+    #[cfg(not(feature = "unlimited_depth"))]
+    #[test]
+    fn test_deeply_nested() {
+        let n = 4000;
+        let mut s = String::with_capacity(n * 2);
+        for _ in 0 .. n {
+            s.push('[')
+        }
+        for _ in 0 .. n {
+            s.push(']')
+        }
+        let res = from_str(s.as_str());
+        assert!(res.is_err());
+        assert!(res.unwrap_err().message.contains("max depth"))
+    }
+
 
     #[test]
     fn test_from_bytes() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -494,6 +494,11 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
         match self.check_and_consume(vec![TokType::Plus, TokType::Minus]) {
             None => self.parse_primary(),
             Some(span) => {
+                self.current_depth = self.current_depth + 1;
+                if self.current_depth > self.max_depth {
+                    let idx = self.position();
+                    return Err(self.make_error(format!("max depth ({}) exceeded while parsing unary. To expand the depth, use the ``with_max_depth`` constructor or enable the `unlimited_depth` feature", self.max_depth), idx))
+                }
                 match span.1 {
                     TokType::Plus => {
                         let value = self.parse_unary()?;
@@ -503,6 +508,7 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
+                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Plus, value: Box::new(value)})
                     }
                     TokType::Minus => {
@@ -513,6 +519,7 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
+                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Minus, value: Box::new(value)})
                     }
                     _ => unreachable!("no")

--- a/src/rt/parser.rs
+++ b/src/rt/parser.rs
@@ -609,6 +609,11 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
         match self.check_and_consume(vec![TokType::Plus, TokType::Minus]) {
             None => self.parse_primary(),
             Some(span) => {
+                self.current_depth = self.current_depth + 1;
+                if self.current_depth > self.max_depth {
+                    let idx = self.position();
+                    return Err(self.make_error(format!("max depth ({}) exceeded while parsing unary. To expand the depth, use the ``with_max_depth`` constructor or enable the `unlimited_depth` feature", self.max_depth), idx))
+                }
                 match span.1 {
                     TokType::Plus => {
                         let value = self.parse_unary()?;
@@ -618,7 +623,7 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
-
+                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Plus, value: Box::new(value)})
                     }
                     TokType::Minus => {
@@ -629,6 +634,7 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
+                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Minus, value: Box::new(value)})
                     }
                     _ => unreachable!("no")

--- a/src/rt/parser.rs
+++ b/src/rt/parser.rs
@@ -609,11 +609,6 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
         match self.check_and_consume(vec![TokType::Plus, TokType::Minus]) {
             None => self.parse_primary(),
             Some(span) => {
-                self.current_depth = self.current_depth + 1;
-                if self.current_depth > self.max_depth {
-                    let idx = self.position();
-                    return Err(self.make_error(format!("max depth ({}) exceeded while parsing unary. To expand the depth, use the ``with_max_depth`` constructor or enable the `unlimited_depth` feature", self.max_depth), idx))
-                }
                 match span.1 {
                     TokType::Plus => {
                         let value = self.parse_unary()?;
@@ -623,7 +618,6 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
-                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Plus, value: Box::new(value)})
                     }
                     TokType::Minus => {
@@ -634,7 +628,6 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
                                 return Err(self.make_error(format!("Unary operations not allowed for value {:?}", val), span.2))
                             }
                         }
-                        self.current_depth = self.current_depth - 1;
                         Ok(JSONValue::Unary {operator: UnaryOperator::Minus, value: Box::new(value)})
                     }
                     _ => unreachable!("no")

--- a/src/rt/parser.rs
+++ b/src/rt/parser.rs
@@ -334,12 +334,19 @@ struct JSON5Parser<'toks, 'input> {
     source: &'input str,
     source_tokens: Peekable<Iter<'toks, TokenSpan>>,
     lookahead: Option<&'toks TokenSpan>,
+    current_depth: usize,
+    max_depth: usize,
 }
 
 
 impl<'toks, 'input> JSON5Parser<'toks, 'input> {
     fn new(tokens: &'toks Tokens<'input>) -> Self {
-        JSON5Parser { source_tokens: tokens.tok_spans.iter().peekable(), lookahead: None, source: tokens.source }
+        use crate::utils::MAX_DEPTH;
+        JSON5Parser { source_tokens: tokens.tok_spans.iter().peekable(), lookahead: None, source: tokens.source, current_depth: 0, max_depth: MAX_DEPTH }
+    }
+
+    fn with_max_depth(&mut self, tokens: &'toks Tokens<'input>, max_depth: usize) -> Self {
+        JSON5Parser { source_tokens: tokens.tok_spans.iter().peekable(), lookahead: None, source: tokens.source, current_depth: 0, max_depth: max_depth }
     }
 
     fn advance(&mut self) -> Option<&'toks TokenSpan> {
@@ -645,7 +652,14 @@ impl<'toks, 'input> JSON5Parser<'toks, 'input> {
 
 
     fn parse_value(&mut self) -> Result<JSONValue, ParsingError> {
-        self.parse_obj_or_array()
+        self.current_depth = self.current_depth + 1;
+        if self.current_depth > self.max_depth {
+            let idx = self.position();
+            return Err(self.make_error(format!("max depth ({}) exceeded in nested arrays/objects. To expand the depth, use the ``with_max_depth`` constructor or enable the `unlimited_depth` feature", self.max_depth), idx))
+        }
+        let res = self.parse_obj_or_array();
+        self.current_depth = self.current_depth - 1;
+        res
     }
 
     fn parse_text(&mut self) -> Result<JSONText, ParsingError> {
@@ -711,6 +725,22 @@ mod tests {
     fn test_fuzz_1() {
         let res = from_str("0xA18 {9");
         assert!(res.is_err());
+    }
+
+    #[cfg(not(feature = "unlimited_depth"))]
+    #[test]
+    fn test_deeply_nested() {
+        let n = 4000;
+        let mut s = String::with_capacity(n * 2);
+        for _ in 0 .. n {
+            s.push('[')
+        }
+        for _ in 0 .. n {
+            s.push(']')
+        }
+        let res = crate::parser::from_str(s.as_str());
+        assert!(res.is_err());
+        assert!(res.unwrap_err().message.contains("max depth"))
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -159,3 +159,20 @@ fn char_from_u32(u: u32) -> Result<char, String> {
 fn err<S: Into<String>>(message: S) -> String {
     message.into()
 }
+
+
+#[cfg(all(not(feature = "unlimited_depth"), not(target_os = "windows"), debug_assertions))]
+pub (crate) const MAX_DEPTH: usize = 1000;
+
+#[cfg(all(not(feature = "unlimited_depth"), not(target_os = "windows"), not(debug_assertions)))]
+pub (crate) const MAX_DEPTH: usize = 3000;
+
+
+#[cfg(all(not(feature = "unlimited_depth"), target_os = "windows", debug_assertions))]
+pub (crate) const MAX_DEPTH: usize = 700;
+
+#[cfg(all(not(feature = "unlimited_depth"), target_os = "windows", not(debug_assertions)))]
+pub (crate) const MAX_DEPTH: usize = 2000;
+
+#[cfg(feature = "unlimited_depth")]
+pub (crate) const MAX_DEPTH: usize = usize::MAX;


### PR DESCRIPTION
This change adds a limit to the nesting depth by default to guard against stack overflow in cases where arrays and/or objects are deeply nested.

Additionally, a new feature, `unlimited_depth` has been added (**disabled** by default) as an easy way for users to bypass this limit.

`JSON5Parser` structs also have a new constructor `with_max_depth` to allow a parser to be constructed with a user-specified max depth.

The default limit aims to prevent stack overflows in most normal circumstances on tier 1 operating systems. Some targets with extremely limited stack space may still experience stack overflows. The limit is adjusted based on operating system and the presence of the `debug_assertions` configuration, intended to allow higher default limits for release builds.

At time of writing, the default limit is as follows:

| Operating System | Depth limit with `debug_assertions` | Depth limit without `debug_assersions` |
|------------------|-------------------------------------|----------------------------------------|
| Windows          | 700                                 | 2000                                   |
| All other OS     | 1000                                | 3000                                   |