### PR TITLE
Handle invalid number literals when document ends with decimal

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -70,7 +70,7 @@ impl<'de, 'a> Deserializer<'de> for JSONValueDeserializer<'a> {
                         visitor.visit_u64(u)
                     } else {
                         // fallback: treat as a string or produce an error
-                        Err(de::Error::custom(format!("Invalid integer {}", s)))
+                        Err(de::Error::custom(format!("Invalid integer literal: {}", s)))
                     }
                 }
             }


### PR DESCRIPTION
Fixes a bug where the tokenizer erroneously interprets a lone decimal as an integer when that decimal is at the very end of the document. Also slightly changes error message for deserialization error (that, before this patch, would have occurred when trying to deserialize such a document).